### PR TITLE
Refine column name mapping between same columns

### DIFF
--- a/prod/policy_tags_service/policy_assignment/sambla_legacy/policy_tags_sambla_legacy.py
+++ b/prod/policy_tags_service/policy_assignment/sambla_legacy/policy_tags_sambla_legacy.py
@@ -63,17 +63,26 @@ def fetch_policy_tags():
     
     return policy_tags
 
+def normalize_name(name):
+    """Normalize the name by converting to lowercase and removing underscores."""
+    return name.lower().replace("_", "")
+
 def match_policy_tags_to_fields(fields, policy_tags, parent_name=None):
     updated_fields = []
+    print(fields)
     
     for field in fields:
         field_name = field["name"]
+        normalized_field_name = normalize_name(field_name)
         
         if field.get('fields'):
             nested_fields = match_policy_tags_to_fields(field["fields"], policy_tags, parent_name=None if field["name"] == "invoices" else parent_name)
             field["fields"] = nested_fields
         else:
-            matching_tag = policy_tags[policy_tags['display_name'] == field_name]
+            # Normalize the policy tags display names for comparison
+            policy_tags['normalized_display_name'] = policy_tags['display_name'].apply(normalize_name)
+            matching_tag = policy_tags[policy_tags['normalized_display_name'] == normalized_field_name]
+            
             if not matching_tag.empty:
                 policy_tag = matching_tag['policy_tag_id'].values[0]
                 field["policyTags"] = {

--- a/prod/policy_tags_service/policy_assignment/templates/get_matching_sensitive_fields.sql
+++ b/prod/policy_tags_service/policy_assignment/templates/get_matching_sensitive_fields.sql
@@ -25,7 +25,7 @@ FROM
 INNER JOIN
   policy_tags AS t2
 ON
-  t1.column_name = t2.display_name
+  LOWER(REPLACE(t1.column_name, '_', '')) = LOWER(REPLACE(t2.display_name, '_', ''))
 -- we filter the only the gdpr_test taxonomy where all the complaint policy tags are created
 WHERE
   t1.table_name not in ("rahalaitos_laina_businessinfo_raha_r","insurance_insurance_gender_raha_r","rahalaitos_laina_decision_data_raha_r")


### PR DESCRIPTION
This PR introduces normalization logic at both the Python code level and SQL query level to minimize the creation of unnecessary policy tags by ensuring field names are matched with existing policy tags, even when different naming conventions are used.

Changes Implemented:
Python Code Normalization:

- Implemented field name normalization logic for sambla_legacy and maxwell.
- This normalization process includes converting field names to lowercase and removing special characters (like underscores) to standardize the naming conventions.
- This ensures that fields such as user_name and userName are matched to a single policy tag, reducing the Increase of redundant policy tags.

SQL Query Normalization:

- Added normalization in SQL queries to handle field matching for others.
- Updated the INNER JOIN condition to apply normalization directly on column_name and display_name, converting both to lowercase and stripping underscores.
- This approach ensures that existing policy tags are reused effectively without creating new tags for slight variations in naming.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209068478135099