### PR TITLE
Bugfix on terraform updates to taxonomy files 

### DIFF
--- a/prod/modules/taxonomy/main.tf
+++ b/prod/modules/taxonomy/main.tf
@@ -30,6 +30,9 @@ resource "google_storage_bucket_object" "taxonomy_csv_file" {
   bucket = google_storage_bucket.taxonomy_bucket.name
   source = abspath("${local.root_csv_path}/taxonomy.csv")  # Replace with your local CSV file path
   depends_on = [ google_storage_bucket.taxonomy_bucket ]
+  lifecycle {
+    ignore_changes = [ source, detect_md5hash ]  # if we make changes in this csv content, we have to comment out this lifecyle block before terraform apply 
+  }
 }
 
 # Upload policy_tags CSV file to the GCS bucket folder
@@ -38,6 +41,9 @@ resource "google_storage_bucket_object" "policy_tags_csv_file" {
   bucket = google_storage_bucket.taxonomy_bucket.name
   source = abspath("${local.root_csv_path}/policy_tags.csv")  # Replace with your local CSV file path
   depends_on = [ google_storage_bucket.taxonomy_bucket ]
+   lifecycle {
+    ignore_changes = [ source, detect_md5hash ] # if we make changes in this csv content, we have to comment out this lifecyle block before terraform apply 
+  }
 }
 
 resource "google_bigquery_table" "taxonomy_bq_table" {


### PR DESCRIPTION
Terraform detects changes in the source path and detect_md5hash attribute of the google_storage_bucket_object resources for taxonomy and policy tags files, even when the source file content remains unchanged. This causes unnecessary in-place updates whenever we change the local, even if no actual changes are required