### PR TITLE
Policy tags permissions

### DIFF
--- a/prod/iam.tf
+++ b/prod/iam.tf
@@ -37,6 +37,27 @@ resource "google_project_iam_binding" "project_permissions_bq_job_user" {
   }          
 }
 
+# Provides permissions to consume policy tags
+resource "google_project_iam_binding" "project_permissions_datacatalog_admin" {
+  project    = var.project_id
+  role               = "roles/datacatalog.admin" 
+  members = [
+    "serviceAccount:${local.service_account}",
+    "serviceAccount:data-flow-pipeline@data-domain-data-warehouse.iam.gserviceaccount.com"
+  ]  
+}
+
+# Provides permissions to consume policy tags
+resource "google_project_iam_binding" "project_permissions_taxonomy_admin" {
+  project    = var.project_id
+  role               = "roles/dataplex.taxonomyAdmin" 
+  members = [
+    "serviceAccount:${local.service_account}",
+    "serviceAccount:data-flow-pipeline@data-domain-data-warehouse.iam.gserviceaccount.com"
+  ]  
+}
+
+
 # Provides permissions to masked read access to columns associated with a data policy.
 resource "google_project_iam_binding" "project_permissions_fine_grained_reader" {
   project    = var.project_id

--- a/prod/modules/taxonomy/iam.tf
+++ b/prod/modules/taxonomy/iam.tf
@@ -1,0 +1,21 @@
+# Dataset Access for SA's to read tables in sambla-data-staging-compliance.policy_tags_metadata
+resource "google_bigquery_dataset_iam_binding" "storage_object_viewer" {
+  dataset_id = var.policy_dataset_id
+  role       = "roles/bigquery.dataViewer"
+  members = [
+    "serviceAccount:data-flow-pipeline@data-domain-data-warehouse.iam.gserviceaccount.com",
+    "serviceAccount:dbt-cloud-job-runner@data-domain-data-warehouse.iam.gserviceaccount.com"
+  ]
+}
+
+
+resource "google_storage_bucket_iam_binding" "binding" {
+  bucket = google_storage_bucket.taxonomy_bucket.name
+  role =  "roles/storage.objectViewer"
+  members = [
+    "serviceAccount:data-flow-pipeline@data-domain-data-warehouse.iam.gserviceaccount.com",
+    "serviceAccount:dbt-cloud-job-runner@data-domain-data-warehouse.iam.gserviceaccount.com"
+  ]
+}
+
+ 

--- a/prod/modules/taxonomy/main.tf
+++ b/prod/modules/taxonomy/main.tf
@@ -64,6 +64,10 @@ resource "google_bigquery_table" "taxonomy_bq_table" {
     # must to define a schema when we create a table
     schema = file("${local.root_schema_path}/taxonomy_schema.json")
     depends_on = [ google_storage_bucket_object.taxonomy_csv_file, google_bigquery_dataset.policy_tags_dataset]
+    # Uncomment this if csv file content is changed
+    lifecycle {
+      ignore_changes = [ schema ]
+    }
 }
 
 resource "google_bigquery_table" "policy_tags_bq_table" {
@@ -83,4 +87,8 @@ resource "google_bigquery_table" "policy_tags_bq_table" {
     # must to define a schema when we create a table
     schema = file("${local.root_schema_path}/policy_tags_schema.json")
     depends_on = [ google_storage_bucket_object.policy_tags_csv_file,google_bigquery_dataset.policy_tags_dataset]
+    # Uncomment this if csv file content is changed
+    lifecycle {
+      ignore_changes = [ schema ]
+    }
 }

--- a/prod/modules/taxonomy/variables.tf
+++ b/prod/modules/taxonomy/variables.tf
@@ -9,3 +9,10 @@ variable "region" {
   type        = string
 }
 
+variable "policy_dataset_id" {
+  description = "The dataset name for policy tags metadata tables"
+  type        = string
+  default = "sambla-data-staging-compliance.policy_tags_metadata"
+
+  
+}

--- a/prod/modules/taxonomy/variables.tf
+++ b/prod/modules/taxonomy/variables.tf
@@ -12,7 +12,7 @@ variable "region" {
 variable "policy_dataset_id" {
   description = "The dataset name for policy tags metadata tables"
   type        = string
-  default = "sambla-data-staging-compliance.policy_tags_metadata"
+  default = "policy_tags_metadata"
 
   
 }

--- a/prod/policy_tags_service/config.yaml
+++ b/prod/policy_tags_service/config.yaml
@@ -3,15 +3,15 @@ default:
     raw_layer_project: "sambla-data-staging-compliance"
     project_location: "europe-north1"
     terraform_sa_secret_name: "terraform-adm-secret-sa"
-    dataset_id: "maxwell_integration_legacy"
-    output_directory: "../../../schemas/maxwell/"
+    dataset_id: "sambla_legacy_integration_legacy"
+    output_directory: "../../../schemas/sambla_legacy/"
     policy_tags_table: "policy_tags_metadata.policy_tags"
 prod:
   policy_tags_service:
     raw_layer_project: "sambla-data-staging-compliance"
     project_location: "europe-north1"
     terraform_sa_secret_name: "terraform-adm-secret-sa"
-    dataset_id: "maxwell_integration_legacy"
-    output_directory: "../../../schemas/maxwell/"
+    dataset_id: "sambla_legacy_integration_legacy"
+    output_directory: "../../../schemas/sambla_legacy/"
     policy_tags_table: "policy_tags_metadata.policy_tags"
 

--- a/prod/policy_tags_service/config.yaml
+++ b/prod/policy_tags_service/config.yaml
@@ -3,15 +3,15 @@ default:
     raw_layer_project: "sambla-data-staging-compliance"
     project_location: "europe-north1"
     terraform_sa_secret_name: "terraform-adm-secret-sa"
-    dataset_id: "sambla_legacy_integration_legacy"
-    output_directory: "../../../schemas/sambla_legacy/"
+    dataset_id: "maxwell_integration_legacy"
+    output_directory: "../../../schemas/maxwell/"
     policy_tags_table: "policy_tags_metadata.policy_tags"
 prod:
   policy_tags_service:
     raw_layer_project: "sambla-data-staging-compliance"
     project_location: "europe-north1"
     terraform_sa_secret_name: "terraform-adm-secret-sa"
-    dataset_id: "sambla_legacy_integration_legacy"
-    output_directory: "../../../schemas/sambla_legacy/"
+    dataset_id: "maxwell_integration_legacy"
+    output_directory: "../../../schemas/maxwell/"
     policy_tags_table: "policy_tags_metadata.policy_tags"
 


### PR DESCRIPTION
# Summary of Changes

- **Introduced IAM permissions** for **service accounts (SA's)** to **read the policy tags metadata tables** in Google BigQuery and access files in Google Cloud Storage.
  - Added **`google_bigquery_dataset_iam_binding`** to grant **read-only access** (`roles/bigquery.dataViewer`) to service accounts such as `data-flow-pipeline` and `dbt-cloud-job-runner` for accessing the **policy tags dataset**.
  - Added **`google_storage_bucket_iam_binding`** to grant the **storage object viewer role** (`roles/storage.objectViewer`) to these service accounts for accessing files in the Cloud Storage bucket.

- **Defined a new variable** `policy_dataset_id` in **`variables.tf`** to specify the dataset for **policy tags metadata tables**, allowing for easier configuration of the dataset ID.

---

This summary highlights the key changes made to implement the IAM permissions for service accounts, update BigQuery table handling, and define the policy dataset ID.
