### PR TITLE
Schemas of LVS, Raha, Salus & Advisa S are all updated with Prod Policy Tags

### DIFF
--- a/prod/schemas/advisa_history/applicants_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/applicants_adhis_r_schema.json
@@ -30,7 +30,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8001475159894173018"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6461865643284600660"
       ]
     }
   },
@@ -40,14 +40,19 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2373830726567021255"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8896656979282780459"
       ]
     }
   },
   {
     "mode": "NULLABLE",
     "name": "civil_status",
-    "type": "INTEGER"
+    "type": "INTEGER",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/700089495488447192"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -55,7 +60,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5274503424278788880"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/8846140171905920944"
       ]
     }
   },
@@ -65,7 +70,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2223969292766117270"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1021770289783624264"
       ]
     }
   },
@@ -75,7 +80,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/7425480497601265433"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/1093311489654391265"
       ]
     }
   },
@@ -85,7 +90,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/614715639179995501"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1553289368757892144"
       ]
     }
   },
@@ -145,7 +150,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2492374698945241881"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/720444043102790014"
       ]
     }
   },
@@ -157,7 +162,12 @@
   {
     "mode": "NULLABLE",
     "name": "politically_exposed",
-    "type": "BOOLEAN"
+    "type": "BOOLEAN",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/1180848125164428807"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -165,7 +175,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8538887370739430117"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/8931050679702196807"
       ]
     }
   },
@@ -180,7 +190,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1469944283301999728"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/1403481017258375676"
       ]
     }
   },

--- a/prod/schemas/advisa_history/applications_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/applications_adhis_r_schema.json
@@ -100,7 +100,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2223969292766117270"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1021770289783624264"
       ]
     }
   },

--- a/prod/schemas/advisa_history/bids_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/bids_adhis_r_schema.json
@@ -75,7 +75,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },

--- a/prod/schemas/advisa_history/cookies_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/cookies_adhis_r_schema.json
@@ -30,7 +30,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2223969292766117270"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1021770289783624264"
       ]
     }
   }

--- a/prod/schemas/advisa_history/credit_report_details_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/credit_report_details_adhis_r_schema.json
@@ -25,7 +25,12 @@
   {
     "mode": "NULLABLE",
     "name": "VALUE",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6031413161488808302"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/advisa_history/credit_report_group_items_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/credit_report_group_items_adhis_r_schema.json
@@ -2,7 +2,12 @@
   {
     "mode": "NULLABLE",
     "name": "VALUE",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6031413161488808302"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/advisa_history/credit_reports_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/credit_reports_adhis_r_schema.json
@@ -25,7 +25,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2223969292766117270"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1021770289783624264"
       ]
     }
   },
@@ -35,7 +35,7 @@
     "type": "BOOLEAN",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/1280180439771065051"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/8906796234689729848"
       ]
     }
   },
@@ -75,7 +75,7 @@
     "type": "BOOLEAN",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/502322662036006619"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/7513431285807343156"
       ]
     }
   },
@@ -95,7 +95,7 @@
     "type": "BOOLEAN",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8435288583699953740"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/9207558630374791829"
       ]
     }
   },

--- a/prod/schemas/advisa_history/creditors_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/creditors_adhis_r_schema.json
@@ -105,7 +105,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/advisa_history/insurance_customers_mdn_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_customers_mdn_adhis_r_schema.json
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/329906415772295222"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/8373617333223940715"
       ]
     }
   },
@@ -30,7 +30,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1728219938699009931"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/1574542865740677443"
       ]
     }
   },
@@ -45,7 +45,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5824688680213173938"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/3598065083198519504"
       ]
     }
   },
@@ -55,7 +55,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4763436523527527963"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6374479179778832352"
       ]
     }
   },
@@ -65,7 +65,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2526892557818933083"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3725510816645287732"
       ]
     }
   },
@@ -90,7 +90,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1633009317526254565"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8886760883540969069"
       ]
     }
   },
@@ -100,7 +100,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2266606811054504985"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4231712925244700379"
       ]
     }
   },
@@ -110,7 +110,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1710768618771408784"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/1920352343748943071"
       ]
     }
   },
@@ -120,7 +120,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3166173652928611319"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/822524415903259490"
       ]
     }
   },
@@ -130,7 +130,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/7094720081026392513"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/7132179794173642846"
       ]
     }
   },
@@ -150,14 +150,19 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3970809602749897195"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/3328688784450368379"
       ]
     }
   },
   {
     "mode": "NULLABLE",
     "name": "customer_birth_date",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/8499947648104922334"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -165,7 +170,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2531213695188202976"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5728314806005871461"
       ]
     }
   },
@@ -175,7 +180,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4852116443936997356"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/168722705519625898"
       ]
     }
   },
@@ -190,7 +195,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8900944629595907796"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8967522264758646642"
       ]
     }
   },
@@ -200,7 +205,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3702254044053173233"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/1551509848487994038"
       ]
     }
   },
@@ -225,7 +230,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/7762607542842849463"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/3202945562909418824"
       ]
     }
   },

--- a/prod/schemas/advisa_history/insurance_insurance_invoices_mutual_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_insurance_invoices_mutual_adhis_r_schema.json
@@ -74,7 +74,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2223969292766117270"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1021770289783624264"
       ]
     }
   },

--- a/prod/schemas/advisa_history/insurance_invoice_items_mutual_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_invoice_items_mutual_adhis_r_schema.json
@@ -54,7 +54,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   }

--- a/prod/schemas/advisa_history/insurance_invoice_lines_mutual_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_invoice_lines_mutual_adhis_r_schema.json
@@ -44,7 +44,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   }

--- a/prod/schemas/advisa_history/insurance_partners_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_partners_adhis_r_schema.json
@@ -21,7 +21,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2755796045912230294"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/7524356136182322399"
       ]
     }
   },

--- a/prod/schemas/advisa_history/insurance_partners_mdn_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_partners_mdn_adhis_r_schema.json
@@ -21,7 +21,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2755796045912230294"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/7524356136182322399"
       ]
     }
   },

--- a/prod/schemas/advisa_history/insurance_payment_insurances_mutual_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_payment_insurances_mutual_adhis_r_schema.json
@@ -70,7 +70,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/10462839579038809"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6032714687553917623"
       ]
     }
   },

--- a/prod/schemas/advisa_history/insurance_payments_mutual_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_payments_mutual_adhis_r_schema.json
@@ -39,7 +39,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   }

--- a/prod/schemas/advisa_history/insurance_policies_mdn_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_policies_mdn_adhis_r_schema.json
@@ -45,7 +45,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2536906608234461143"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4873057110205642644"
       ]
     }
   },
@@ -55,7 +55,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2213337399800769894"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/2273280132614168581"
       ]
     }
   },

--- a/prod/schemas/advisa_history/insurance_repayments_mutual_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_repayments_mutual_adhis_r_schema.json
@@ -20,7 +20,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },
@@ -37,7 +37,12 @@
   {
     "mode": "NULLABLE",
     "name": "comments",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6648053288186094991"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/advisa_history/insurance_transactions_mdn_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_transactions_mdn_adhis_r_schema.json
@@ -5,7 +5,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2213337399800769894"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/2273280132614168581"
       ]
     }
   },
@@ -21,7 +21,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2536906608234461143"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4873057110205642644"
       ]
     }
   },

--- a/prod/schemas/advisa_history/insurance_users_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_users_adhis_r_schema.json
@@ -21,7 +21,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     }
   },
@@ -41,7 +41,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     }
   },

--- a/prod/schemas/advisa_history/insurance_users_mdn_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/insurance_users_mdn_adhis_r_schema.json
@@ -21,7 +21,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     }
   },
@@ -41,7 +41,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     }
   },

--- a/prod/schemas/advisa_history/invoices_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/invoices_adhis_r_schema.json
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8897761895887324175"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3654978517879767075"
       ]
     }
   },

--- a/prod/schemas/advisa_history/people_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/people_adhis_r_schema.json
@@ -25,7 +25,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2223969292766117270"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1021770289783624264"
       ]
     }
   },
@@ -35,7 +35,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/6863647573685228642"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5051177413198927114"
       ]
     }
   },
@@ -45,7 +45,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2530336514736091887"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8190767684129261300"
       ]
     }
   },

--- a/prod/schemas/advisa_history/subscription_month_invoice_items_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/subscription_month_invoice_items_adhis_r_schema.json
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8897761895887324175"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3654978517879767075"
       ]
     }
   },

--- a/prod/schemas/advisa_history/subscriptions_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/subscriptions_adhis_r_schema.json
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8897761895887324175"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3654978517879767075"
       ]
     }
   },

--- a/prod/schemas/advisa_history/tags_adhis_r_schema.json
+++ b/prod/schemas/advisa_history/tags_adhis_r_schema.json
@@ -57,6 +57,11 @@
   {
     "mode": "NULLABLE",
     "name": "value",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6031413161488808302"
+      ]
+    }
   }
 ]

--- a/prod/schemas/lvs/applicants_lvs_r_schema.json
+++ b/prod/schemas/lvs/applicants_lvs_r_schema.json
@@ -14,12 +14,22 @@
       {
         "mode": "NULLABLE",
         "name": "salary_monthly_net",
-        "type": "STRING"
+        "type": "STRING",
+        "policyTags": {
+          "names": [
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7677596943207196950"
+          ]
+        }
       },
       {
         "mode": "NULLABLE",
         "name": "salary_monthly_gross",
-        "type": "STRING"
+        "type": "STRING",
+        "policyTags": {
+          "names": [
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4159175221921907153"
+          ]
+        }
       },
       {
         "mode": "NULLABLE",
@@ -94,7 +104,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/6608376575111469545"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/368681235308034403"
       ]
     }
   },
@@ -119,7 +129,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4431446724316501430"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6226721672907170585"
       ]
     }
   },
@@ -129,7 +139,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5143724156946537013"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/2695049525387444910"
       ]
     }
   },
@@ -144,7 +154,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     }
   },
@@ -166,7 +176,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/7171368587317656388"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2002820261517347430"
           ]
         }
       },
@@ -176,7 +186,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1199745607424124840"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/270889134539559221"
           ]
         }
       },
@@ -186,7 +196,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/526497518428814285"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/1000284766421328938"
           ]
         }
       },
@@ -211,14 +221,19 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8503996682985551914"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5757293661518724631"
           ]
         }
       },
       {
         "mode": "NULLABLE",
         "name": "occupation",
-        "type": "STRING"
+        "type": "STRING",
+        "policyTags": {
+          "names": [
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/45742810527122249"
+          ]
+        }
       },
       {
         "mode": "NULLABLE",
@@ -226,7 +241,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4507853496904095067"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3317539461820597114"
           ]
         }
       },
@@ -283,7 +298,7 @@
         "type": "FLOAT",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
           ]
         }
       },
@@ -323,7 +338,7 @@
     "type": "BOOLEAN",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/938517285111359883"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/6637940785736702004"
       ]
     }
   },
@@ -333,7 +348,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8001475159894173018"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6461865643284600660"
       ]
     }
   },
@@ -343,7 +358,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/9107101934449682178"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2364795875905812308"
       ]
     }
   },
@@ -353,7 +368,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1841188998749619886"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6833665301934383846"
       ]
     }
   },
@@ -363,7 +378,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5967090950065027761"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4906941243699927382"
       ]
     }
   },
@@ -373,7 +388,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     }
   },
@@ -420,7 +435,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9181862660018028858"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1253511512061036131"
       ]
     }
   },
@@ -472,7 +487,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },
@@ -482,7 +497,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7051526824838973807"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/511583085911940693"
       ]
     }
   },
@@ -492,7 +507,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7397601329273246316"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/7892252738755325211"
       ]
     }
   },
@@ -502,7 +517,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8404501393127763289"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6613650332470153365"
       ]
     }
   },
@@ -512,7 +527,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2373830726567021255"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8896656979282780459"
       ]
     }
   },

--- a/prod/schemas/lvs/applications_lvs_r_schema.json
+++ b/prod/schemas/lvs/applications_lvs_r_schema.json
@@ -9,7 +9,12 @@
       {
         "mode": "NULLABLE",
         "name": "value",
-        "type": "FLOAT"
+        "type": "FLOAT",
+        "policyTags": {
+          "names": [
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6031413161488808302"
+          ]
+        }
       },
       {
         "mode": "NULLABLE",
@@ -320,7 +325,12 @@
           {
             "mode": "REPEATED",
             "name": "occupation",
-            "type": "STRING"
+            "type": "STRING",
+            "policyTags": {
+              "names": [
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/45742810527122249"
+              ]
+            }
           },
           {
             "mode": "NULLABLE",

--- a/prod/schemas/lvs/applications_lvs_schema.json
+++ b/prod/schemas/lvs/applications_lvs_schema.json
@@ -9,7 +9,12 @@
       {
         "mode": "NULLABLE",
         "name": "value",
-        "type": "FLOAT"
+        "type": "FLOAT",
+        "policyTags": {
+          "names": [
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6031413161488808302"
+          ]
+        }
       },
       {
         "mode": "NULLABLE",
@@ -205,12 +210,22 @@
           {
             "mode": "NULLABLE",
             "name": "salary_monthly_net",
-            "type": "STRING"
+            "type": "STRING",
+            "policyTags": {
+              "names": [
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7677596943207196950"
+              ]
+            }
           },
           {
             "mode": "NULLABLE",
             "name": "salary_monthly_gross",
-            "type": "STRING"
+            "type": "STRING",
+            "policyTags": {
+              "names": [
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4159175221921907153"
+              ]
+            }
           },
           {
             "mode": "NULLABLE",
@@ -285,7 +300,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8404501393127763289"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6613650332470153365"
           ]
         }
       },
@@ -295,7 +310,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/6608376575111469545"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/368681235308034403"
           ]
         }
       },
@@ -315,7 +330,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7397601329273246316"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/7892252738755325211"
           ]
         }
       },
@@ -330,7 +345,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4431446724316501430"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6226721672907170585"
           ]
         }
       },
@@ -340,7 +355,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5143724156946537013"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/2695049525387444910"
           ]
         }
       },
@@ -350,7 +365,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
           ]
         }
       },
@@ -377,7 +392,7 @@
             "type": "STRING",
             "policyTags": {
               "names": [
-                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/7171368587317656388"
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2002820261517347430"
               ]
             }
           },
@@ -387,7 +402,7 @@
             "type": "STRING",
             "policyTags": {
               "names": [
-                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1199745607424124840"
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/270889134539559221"
               ]
             }
           },
@@ -397,7 +412,7 @@
             "type": "STRING",
             "policyTags": {
               "names": [
-                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/526497518428814285"
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/1000284766421328938"
               ]
             }
           },
@@ -422,14 +437,19 @@
             "type": "STRING",
             "policyTags": {
               "names": [
-                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8503996682985551914"
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5757293661518724631"
               ]
             }
           },
           {
             "mode": "NULLABLE",
             "name": "occupation",
-            "type": "STRING"
+            "type": "STRING",
+            "policyTags": {
+              "names": [
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/45742810527122249"
+              ]
+            }
           },
           {
             "mode": "NULLABLE",
@@ -437,7 +457,7 @@
             "type": "STRING",
             "policyTags": {
               "names": [
-                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4507853496904095067"
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3317539461820597114"
               ]
             }
           },
@@ -494,7 +514,7 @@
             "type": "FLOAT",
             "policyTags": {
               "names": [
-                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
               ]
             }
           },
@@ -534,7 +554,7 @@
         "type": "BOOLEAN",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/938517285111359883"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/6637940785736702004"
           ]
         }
       },
@@ -544,7 +564,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8001475159894173018"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6461865643284600660"
           ]
         }
       },
@@ -554,7 +574,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/9107101934449682178"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2364795875905812308"
           ]
         }
       },
@@ -564,7 +584,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1841188998749619886"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6833665301934383846"
           ]
         }
       },
@@ -574,7 +594,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5967090950065027761"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4906941243699927382"
           ]
         }
       },
@@ -584,7 +604,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
           ]
         }
       },
@@ -631,7 +651,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9181862660018028858"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1253511512061036131"
           ]
         }
       },
@@ -683,7 +703,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
           ]
         }
       },
@@ -693,7 +713,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7051526824838973807"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/511583085911940693"
           ]
         }
       },
@@ -703,7 +723,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2373830726567021255"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8896656979282780459"
           ]
         }
       },
@@ -854,7 +874,12 @@
           {
             "mode": "REPEATED",
             "name": "occupation",
-            "type": "STRING"
+            "type": "STRING",
+            "policyTags": {
+              "names": [
+                "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/45742810527122249"
+              ]
+            }
           },
           {
             "mode": "NULLABLE",

--- a/prod/schemas/lvs/clients_lvs_r_schema.json
+++ b/prod/schemas/lvs/clients_lvs_r_schema.json
@@ -30,7 +30,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5967090950065027761"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4906941243699927382"
       ]
     }
   },
@@ -43,7 +43,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },
@@ -52,7 +52,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7051526824838973807"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/511583085911940693"
       ]
     }
   },
@@ -61,7 +61,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9181862660018028858"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1253511512061036131"
       ]
     }
   },
@@ -70,7 +70,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1841188998749619886"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6833665301934383846"
       ]
     }
   },
@@ -79,7 +79,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/9107101934449682178"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2364795875905812308"
       ]
     }
   },
@@ -88,7 +88,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8404501393127763289"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6613650332470153365"
       ]
     }
   },
@@ -97,7 +97,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2373830726567021255"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8896656979282780459"
       ]
     }
   },
@@ -106,7 +106,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     }
   },
@@ -115,7 +115,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     }
   }

--- a/prod/schemas/lvs/credit_remarks_lvs_r_schema.json
+++ b/prod/schemas/lvs/credit_remarks_lvs_r_schema.json
@@ -11,7 +11,7 @@
                 "type": "STRING",
                 "policyTags": {
                   "names": [
-                    "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8404501393127763289"
+                    "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6613650332470153365"
                   ]
                 }
               },
@@ -26,7 +26,7 @@
                 "type": "STRING",
                 "policyTags": {
                   "names": [
-                    "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+                    "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
                   ]
                 }
               },
@@ -200,7 +200,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
           ]
         }
       },
@@ -312,7 +312,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/lvs/p_layer/applicants_lvs_p_schema.json
+++ b/prod/schemas/lvs/p_layer/applicants_lvs_p_schema.json
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     }
   },
@@ -29,7 +29,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     }
   },
@@ -38,7 +38,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5967090950065027761"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4906941243699927382"
       ]
     }
   },
@@ -47,7 +47,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1841188998749619886"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6833665301934383846"
       ]
     }
   },
@@ -60,7 +60,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9181862660018028858"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1253511512061036131"
       ]
     }
   },
@@ -69,7 +69,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },
@@ -78,7 +78,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7051526824838973807"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/511583085911940693"
       ]
     }
   },
@@ -87,7 +87,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4431446724316501430"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6226721672907170585"
       ]
     }
   },
@@ -100,7 +100,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2373830726567021255"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8896656979282780459"
       ]
     }
   },
@@ -109,7 +109,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/9107101934449682178"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2364795875905812308"
       ]
     }
   },
@@ -118,7 +118,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8404501393127763289"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6613650332470153365"
       ]
     }
   },
@@ -127,7 +127,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/6608376575111469545"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/368681235308034403"
       ]
     }
   },
@@ -136,7 +136,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8001475159894173018"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6461865643284600660"
       ]
     }
   },
@@ -149,7 +149,7 @@
     "type": "BOOLEAN",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/938517285111359883"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/6637940785736702004"
       ]
     }
   },
@@ -166,7 +166,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5143724156946537013"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/2695049525387444910"
       ]
     }
   },
@@ -175,7 +175,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7397601329273246316"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/7892252738755325211"
       ]
     }
   },
@@ -248,7 +248,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5932609567272540860"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5301958019033477339"
       ]
     }
   },
@@ -257,7 +257,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4281468088345391380"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5695798838319725896"
       ]
     }
   },
@@ -274,7 +274,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/7982079890432511702"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/874137576898303868"
       ]
     }
   },
@@ -287,7 +287,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4507853496904095067"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3317539461820597114"
       ]
     }
   },

--- a/prod/schemas/lvs/p_layer/clients_lvs_p_schema.json
+++ b/prod/schemas/lvs/p_layer/clients_lvs_p_schema.json
@@ -4,7 +4,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5967090950065027761"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4906941243699927382"
       ]
     }
   },
@@ -17,7 +17,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },
@@ -26,7 +26,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9181862660018028858"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1253511512061036131"
       ]
     }
   },
@@ -35,7 +35,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1841188998749619886"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6833665301934383846"
       ]
     }
   },
@@ -44,7 +44,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/9107101934449682178"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2364795875905812308"
       ]
     }
   },
@@ -53,7 +53,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8404501393127763289"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6613650332470153365"
       ]
     }
   },
@@ -62,7 +62,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2373830726567021255"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8896656979282780459"
       ]
     }
   },
@@ -71,7 +71,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     }
   },
@@ -80,7 +80,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     }
   },
@@ -109,7 +109,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/6863647573685228642"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5051177413198927114"
       ]
     }
   }

--- a/prod/schemas/lvs/p_layer/credit_remarks_lvs_p_schema.json
+++ b/prod/schemas/lvs/p_layer/credit_remarks_lvs_p_schema.json
@@ -8,7 +8,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/lvs/p_layer/provider_commissions_lvs_p_schema.json
+++ b/prod/schemas/lvs/p_layer/provider_commissions_lvs_p_schema.json
@@ -40,7 +40,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4258342891448046031"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5014902748259229731"
       ]
     }
   },
@@ -54,7 +54,12 @@
   },
   {
     "name": "value",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6031413161488808302"
+      ]
+    }
   },
   {
     "name": "loan_min",

--- a/prod/schemas/lvs/p_layer/providers_lvs_p_schema.json
+++ b/prod/schemas/lvs/p_layer/providers_lvs_p_schema.json
@@ -46,7 +46,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/1442195305043274617"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5427110230140285040"
       ]
     }
   },
@@ -59,7 +59,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8900944629595907796"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8967522264758646642"
       ]
     }
   },
@@ -80,7 +80,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4852116443936997356"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/168722705519625898"
       ]
     }
   },
@@ -97,7 +97,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },
@@ -118,7 +118,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },

--- a/prod/schemas/lvs/providers_lvs_r_schema.json
+++ b/prod/schemas/lvs/providers_lvs_r_schema.json
@@ -42,7 +42,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/1442195305043274617"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5427110230140285040"
       ]
     }
   },
@@ -57,7 +57,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8900944629595907796"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8967522264758646642"
       ]
     }
   },
@@ -87,7 +87,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4852116443936997356"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/168722705519625898"
       ]
     }
   },
@@ -107,7 +107,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },
@@ -171,7 +171,7 @@
         "type": "STRING",
         "policyTags": {
           "names": [
-            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4258342891448046031"
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5014902748259229731"
           ]
         }
       },
@@ -188,7 +188,12 @@
       {
         "mode": "NULLABLE",
         "name": "value",
-        "type": "STRING"
+        "type": "STRING",
+        "policyTags": {
+          "names": [
+            "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6031413161488808302"
+          ]
+        }
       },
       {
         "mode": "NULLABLE",
@@ -226,7 +231,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/crm_user_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/crm_user_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7281891383648503186"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8410960888773883067"
       ]
     }
   },
@@ -25,7 +25,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },
@@ -35,7 +35,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9181862660018028858"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1253511512061036131"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_agreement_type_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_agreement_type_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_history_details_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_history_details_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6031413161488808302"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_history_type_priority_level_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_history_type_priority_level_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_history_type_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_history_type_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_insurance_details_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_insurance_details_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_insurance_gender_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_insurance_gender_raha_r_schema.json
@@ -12,7 +12,12 @@
   {
     "mode": "NULLABLE",
     "name": "value",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6031413161488808302"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/rahalaitos/insurance_insurance_language_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_insurance_language_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_insurance_personal_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_insurance_personal_raha_r_schema.json
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3872124298716686870"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7670462186456590235"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_insurance_product_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_insurance_product_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_insurance_status_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_insurance_status_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_log_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_log_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8897761895887324175"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3654978517879767075"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_person_identify_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_person_identify_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8263227758085782345"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/insurance_person_information_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/insurance_person_information_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     }
   },
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     }
   },
@@ -30,7 +30,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/7844209228244700126"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/7921800904692288032"
       ]
     }
   },
@@ -45,7 +45,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5166604514616614536"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/2888287269054757620"
       ]
     }
   },
@@ -55,7 +55,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/marketing_applicant_business_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/marketing_applicant_business_raha_r_schema.json
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2176204542861538863"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6336776306351602597"
       ]
     }
   },
@@ -30,7 +30,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7971345771247161278"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4981946386541817851"
       ]
     }
   },
@@ -40,7 +40,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4388140267087059578"
       ]
     }
   },
@@ -50,7 +50,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },
@@ -60,7 +60,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3872124298716686870"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7670462186456590235"
       ]
     }
   },
@@ -70,7 +70,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5967090950065027761"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4906941243699927382"
       ]
     }
   },
@@ -80,7 +80,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4379069429822051426"
       ]
     }
   },
@@ -120,7 +120,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2624452233356343246"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2990713445341371115"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/marketing_applicant_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/marketing_applicant_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/6578286788810104971"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8676875422466440081"
       ]
     }
   },
@@ -35,7 +35,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2176204542861538863"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6336776306351602597"
       ]
     }
   },
@@ -45,7 +45,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7971345771247161278"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4981946386541817851"
       ]
     }
   },
@@ -55,7 +55,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4388140267087059578"
       ]
     }
   },
@@ -65,7 +65,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },
@@ -75,7 +75,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3441603319572544283"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4694819595261833950"
       ]
     }
   },
@@ -85,7 +85,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/2405882741139641535"
       ]
     }
   },
@@ -95,7 +95,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4956759611222142988"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/942629323279173641"
       ]
     }
   },
@@ -105,7 +105,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3872124298716686870"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7670462186456590235"
       ]
     }
   },
@@ -115,7 +115,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5967090950065027761"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4906941243699927382"
       ]
     }
   },
@@ -140,7 +140,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7293872225241612745"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/9087674057733671967"
       ]
     }
   },
@@ -177,7 +177,12 @@
   {
     "mode": "NULLABLE",
     "name": "bruttotulot",
-    "type": "INTEGER"
+    "type": "INTEGER",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7271466154088881359"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -255,7 +260,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/6625321257964193021"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4243850254303011360"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/marketing_external_marketing_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/marketing_external_marketing_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2176204542861538863"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6336776306351602597"
       ]
     }
   },
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7971345771247161278"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4981946386541817851"
       ]
     }
   },
@@ -30,19 +30,29 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3441603319572544283"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4694819595261833950"
       ]
     }
   },
   {
     "mode": "NULLABLE",
     "name": "postinumero",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4006941670285820825"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
     "name": "paikkakunta",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1678090656783231294"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -50,7 +60,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },
@@ -60,7 +70,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4388140267087059578"
       ]
     }
   },
@@ -72,7 +82,12 @@
   {
     "mode": "NULLABLE",
     "name": "sukupuoli",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/8039236770035332469"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/rahalaitos/rahalaitos_all_customers_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_all_customers_r_schema.json
@@ -5,7 +5,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_application_ispep_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_application_ispep_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/938517285111359883"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/6637940785736702004"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_campaign_bing_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_campaign_bing_raha_r_schema.json
@@ -7,7 +7,12 @@
   {
     "mode": "NULLABLE",
     "name": "identifier",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/48492384500970620"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/rahalaitos/rahalaitos_campaign_facebook_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_campaign_facebook_raha_r_schema.json
@@ -7,7 +7,12 @@
   {
     "mode": "NULLABLE",
     "name": "identifier",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/48492384500970620"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/rahalaitos/rahalaitos_campaign_google_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_campaign_google_raha_r_schema.json
@@ -7,7 +7,12 @@
   {
     "mode": "NULLABLE",
     "name": "identifier",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/48492384500970620"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/rahalaitos/rahalaitos_citizenShip_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_citizenShip_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8001475159894173018"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6461865643284600660"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_company_types_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_company_types_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_customer_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_customer_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7051526824838973807"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/511583085911940693"
       ]
     }
   },
@@ -25,7 +25,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3872124298716686870"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7670462186456590235"
       ]
     }
   },
@@ -35,7 +35,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5967090950065027761"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4906941243699927382"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_incomplete_applications_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_incomplete_applications_r_schema.json
@@ -5,7 +5,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_laina_bankinfo_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_bankinfo_raha_r_schema.json
@@ -75,7 +75,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7293872225241612745"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/9087674057733671967"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_laina_brands_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_brands_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_laina_businessinfo_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_businessinfo_raha_r_schema.json
@@ -7,7 +7,12 @@
   {
     "mode": "NULLABLE",
     "name": "business_address",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4379069429822051426"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/rahalaitos/rahalaitos_laina_companyinfo_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_companyinfo_raha_r_schema.json
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2624452233356343246"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2990713445341371115"
       ]
     }
   },
@@ -42,12 +42,22 @@
   {
     "mode": "NULLABLE",
     "name": "nettotulos",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/704838162045412265"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
     "name": "liikevaihto",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/1782653178522950431"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -55,7 +65,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/6088913950501142826"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5816539005103612349"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_laina_contactinfo_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_contactinfo_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/2176204542861538863"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6336776306351602597"
       ]
     }
   },
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7971345771247161278"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4981946386541817851"
       ]
     }
   },
@@ -30,7 +30,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3441603319572544283"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4694819595261833950"
       ]
     }
   },
@@ -40,7 +40,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4956759611222142988"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/942629323279173641"
       ]
     }
   },
@@ -50,7 +50,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/2405882741139641535"
       ]
     }
   },
@@ -60,14 +60,19 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4388140267087059578"
       ]
     }
   },
   {
     "mode": "NULLABLE",
     "name": "tyopuhelin",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/7494069836928770718"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -75,7 +80,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },
@@ -85,7 +90,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/6578286788810104971"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8676875422466440081"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_laina_decision_data_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_decision_data_raha_r_schema.json
@@ -17,7 +17,12 @@
   {
     "mode": "NULLABLE",
     "name": "value",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6031413161488808302"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/rahalaitos/rahalaitos_laina_decision_data_types_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_decision_data_types_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_laina_decision_history_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_decision_history_raha_r_schema.json
@@ -30,7 +30,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_laina_generalinfo_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_generalinfo_raha_r_schema.json
@@ -7,7 +7,12 @@
   {
     "mode": "NULLABLE",
     "name": "kansalaisuus",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7531419600413626810"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -17,7 +22,12 @@
   {
     "mode": "NULLABLE",
     "name": "siviilisaaty",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/1955415658048578536"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -62,7 +72,12 @@
   {
     "mode": "NULLABLE",
     "name": "koulutus",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/445187592719076744"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/rahalaitos/rahalaitos_laina_kieltolista_sms_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_kieltolista_sms_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4388140267087059578"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_laina_tag_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_tag_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_laina_workinfo_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_workinfo_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7497603640112848285"
       ]
     }
   },
@@ -30,7 +30,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/8079091799678586940"
       ]
     }
   },
@@ -40,7 +40,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5930425938369960379"
       ]
     }
   },
@@ -62,7 +62,12 @@
   {
     "mode": "NULLABLE",
     "name": "edtyonantaja",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/9020389780437670432"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -77,7 +82,12 @@
   {
     "mode": "NULLABLE",
     "name": "bruttotulot",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7271466154088881359"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -92,7 +102,12 @@
   {
     "mode": "NULLABLE",
     "name": "nettotulot",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/8354583460841805127"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",

--- a/prod/schemas/rahalaitos/rahalaitos_laina_yv_candidateinfo_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_laina_yv_candidateinfo_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8223455317484676046"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8272260378015189860"
       ]
     }
   },
@@ -20,7 +20,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8864486779901089232"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8933381253932809659"
       ]
     }
   },
@@ -30,7 +30,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4951727479303231826"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/3126507930273585323"
       ]
     }
   },
@@ -40,7 +40,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/65935253438914772"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4169521934647778193"
       ]
     }
   },
@@ -50,7 +50,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/2562564577007341107"
       ]
     }
   },
@@ -60,19 +60,29 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/2825344361870182648"
       ]
     }
   },
   {
     "mode": "NULLABLE",
     "name": "yv_tyopuhelin",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5914691110315296325"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
     "name": "yv_asuu",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/207433813710578403"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -80,7 +90,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8845249109474988189"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4791447502047941372"
       ]
     }
   },
@@ -90,7 +100,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/9016228568754921630"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6072248175244107074"
       ]
     }
   },
@@ -100,7 +110,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/7544159846056063820"
       ]
     }
   },
@@ -110,7 +120,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/6126692965998272750/policyTags/1064433561942680153"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308107332426815801"
       ]
     }
   },
@@ -125,19 +135,29 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/7096807766487053132"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6544112304554845806"
       ]
     }
   },
   {
     "mode": "NULLABLE",
     "name": "yv_bruttotulot",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5058794603843392354"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
     "name": "yv_nettotulot",
-    "type": "STRING"
+    "type": "STRING",
+    "policyTags": {
+      "names": [
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6219648779626988816"
+      ]
+    }
   },
   {
     "mode": "NULLABLE",
@@ -155,7 +175,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3410223528870524659"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6952721143831549593"
       ]
     }
   },
@@ -165,7 +185,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5095211408361394220"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/6318966399766754487"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_loan_applicant_type_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_loan_applicant_type_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_loan_type_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_loan_type_raha_r_schema.json
@@ -15,7 +15,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_marketing_email_temp_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_marketing_email_temp_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },

--- a/prod/schemas/rahalaitos/rahalaitos_marketing_sms_temp_raha_r_schema.json
+++ b/prod/schemas/rahalaitos/rahalaitos_marketing_sms_temp_raha_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9181862660018028858"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1253511512061036131"
       ]
     }
   },

--- a/prod/schemas/salus/accounts_salus_r_schema.json
+++ b/prod/schemas/salus/accounts_salus_r_schema.json
@@ -10,7 +10,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7281891383648503186"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8410960888773883067"
       ]
     }
   },
@@ -30,7 +30,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     }
   },
@@ -40,7 +40,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     }
   },
@@ -50,7 +50,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     }
   },

--- a/prod/schemas/salus/applicant-jobs_salus_r_schema.json
+++ b/prod/schemas/salus/applicant-jobs_salus_r_schema.json
@@ -30,7 +30,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4507853496904095067"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3317539461820597114"
       ]
     }
   },
@@ -40,7 +40,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1199745607424124840"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/270889134539559221"
       ]
     }
   },
@@ -55,7 +55,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2669598821160064075"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/605926281244245758"
       ]
     }
   },
@@ -65,7 +65,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/416145839786831247"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6071619618436593663"
       ]
     }
   },
@@ -75,7 +75,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8959222113553357339"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/928990002786230167"
       ]
     }
   },
@@ -85,7 +85,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3184611772527250122"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3729272540755511892"
       ]
     }
   },

--- a/prod/schemas/salus/applicant-loans_salus_r_schema.json
+++ b/prod/schemas/salus/applicant-loans_salus_r_schema.json
@@ -15,7 +15,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },

--- a/prod/schemas/salus/applicants_salus_r_schema.json
+++ b/prod/schemas/salus/applicants_salus_r_schema.json
@@ -10,7 +10,7 @@
     "type": "TIMESTAMP",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/6625321257964193021"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4243850254303011360"
       ]
     }
   },
@@ -25,7 +25,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     }
   },
@@ -35,7 +35,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     }
   },
@@ -45,7 +45,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5967090950065027761"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4906941243699927382"
       ]
     }
   },
@@ -55,7 +55,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4431446724316501430"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6226721672907170585"
       ]
     }
   },
@@ -65,7 +65,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/7821052334953675791"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2852413864562398649"
       ]
     }
   },
@@ -75,7 +75,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/6608376575111469545"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/368681235308034403"
       ]
     }
   },
@@ -100,7 +100,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     }
   },
@@ -110,7 +110,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9181862660018028858"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1253511512061036131"
       ]
     }
   },
@@ -120,7 +120,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7051526824838973807"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/511583085911940693"
       ]
     }
   },
@@ -130,7 +130,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8404501393127763289"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6613650332470153365"
       ]
     }
   },
@@ -140,7 +140,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2373830726567021255"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8896656979282780459"
       ]
     }
   },
@@ -150,7 +150,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2718925012891173808"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5409377275640902119"
       ]
     }
   },

--- a/prod/schemas/salus/applications_salus_r_schema.json
+++ b/prod/schemas/salus/applications_salus_r_schema.json
@@ -135,7 +135,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },
@@ -155,7 +155,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8200763276510798683"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/2811384579850779811"
       ]
     }
   },
@@ -170,7 +170,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7383053594225766630"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/181631412835176732"
       ]
     }
   },

--- a/prod/schemas/salus/bids_salus_r_schema.json
+++ b/prod/schemas/salus/bids_salus_r_schema.json
@@ -40,7 +40,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },

--- a/prod/schemas/salus/commision-rules_salus_r_schema.json
+++ b/prod/schemas/salus/commision-rules_salus_r_schema.json
@@ -65,7 +65,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8807586895720374217"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/3220636305578737722"
       ]
     }
   },
@@ -80,7 +80,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9049668318568313695"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/2913188619180285017"
       ]
     }
   },
@@ -90,7 +90,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/1317546347564314630"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/4790044520415782966"
       ]
     }
   },
@@ -100,7 +100,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/944449308723351742"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/46229461511594618"
       ]
     }
   },
@@ -110,7 +110,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/6318793431926689090"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/8632342627650399544"
       ]
     }
   },
@@ -120,7 +120,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/152022143728259999"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/3293766125132595059"
       ]
     }
   },
@@ -130,7 +130,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5283687123813568820"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/4960776295532357999"
       ]
     }
   }

--- a/prod/schemas/salus/invitations_salus_r_schema.json
+++ b/prod/schemas/salus/invitations_salus_r_schema.json
@@ -35,7 +35,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   }

--- a/prod/schemas/salus/upstream/accounts_salus_incremental_r_schema.json
+++ b/prod/schemas/salus/upstream/accounts_salus_incremental_r_schema.json
@@ -7,7 +7,7 @@
     "name": "username",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7281891383648503186"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8410960888773883067"
       ]
     },
     "type": "STRING"
@@ -24,7 +24,7 @@
     "name": "name",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3997340774018070165"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/5910743820384249379"
       ]
     },
     "type": "STRING"
@@ -33,7 +33,7 @@
     "name": "firstname",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     },
     "type": "STRING"
@@ -42,7 +42,7 @@
     "name": "lastname",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     },
     "type": "STRING"

--- a/prod/schemas/salus/upstream/applicant-jobs_salus_incremental_r_schema.json
+++ b/prod/schemas/salus/upstream/applicant-jobs_salus_incremental_r_schema.json
@@ -23,7 +23,7 @@
     "name": "employer",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4507853496904095067"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3317539461820597114"
       ]
     },
     "type": "STRING"
@@ -32,7 +32,7 @@
     "name": "profession",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/1199745607424124840"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/270889134539559221"
       ]
     },
     "type": "STRING"
@@ -46,7 +46,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2669598821160064075"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/605926281244245758"
       ]
     }
   },
@@ -55,7 +55,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/416145839786831247"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6071619618436593663"
       ]
     }
   },
@@ -64,7 +64,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8959222113553357339"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/928990002786230167"
       ]
     }
   },
@@ -73,7 +73,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/3184611772527250122"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/3729272540755511892"
       ]
     }
   },

--- a/prod/schemas/salus/upstream/applicant-loans_salus_incremental_r_schema.json
+++ b/prod/schemas/salus/upstream/applicant-loans_salus_incremental_r_schema.json
@@ -12,7 +12,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },

--- a/prod/schemas/salus/upstream/applicants_salus_incremental_r_schema.json
+++ b/prod/schemas/salus/upstream/applicants_salus_incremental_r_schema.json
@@ -8,7 +8,7 @@
     "type": "TIMESTAMP",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/6625321257964193021"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4243850254303011360"
       ]
     }
   },
@@ -20,7 +20,7 @@
     "name": "firstname",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/3438195291922151573"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8490938856311491456"
       ]
     },
     "type": "STRING"
@@ -29,7 +29,7 @@
     "name": "lastname",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5998817033341608997"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4459336840846216239"
       ]
     },
     "type": "STRING"
@@ -39,7 +39,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5967090950065027761"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/4906941243699927382"
       ]
     }
   },
@@ -48,7 +48,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/4431446724316501430"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/6226721672907170585"
       ]
     }
   },
@@ -57,7 +57,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/7821052334953675791"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/2852413864562398649"
       ]
     }
   },
@@ -66,7 +66,7 @@
     "type": "STRING",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/6608376575111469545"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/368681235308034403"
       ]
     }
   },
@@ -86,7 +86,7 @@
     "name": "email",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/4190779673109096674"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/4089129269302642070"
       ]
     },
     "type": "STRING"
@@ -95,7 +95,7 @@
     "name": "phone",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9181862660018028858"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/1253511512061036131"
       ]
     },
     "type": "STRING"
@@ -104,7 +104,7 @@
     "name": "ssn",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7051526824838973807"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/511583085911940693"
       ]
     },
     "type": "STRING"
@@ -113,7 +113,7 @@
     "name": "address",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/8404501393127763289"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/6613650332470153365"
       ]
     },
     "type": "STRING"
@@ -122,7 +122,7 @@
     "name": "city",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2373830726567021255"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/7698000960465061299/policyTags/8896656979282780459"
       ]
     },
     "type": "STRING"
@@ -131,7 +131,7 @@
     "name": "zip",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/2718925012891173808"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5409377275640902119"
       ]
     },
     "type": "STRING"

--- a/prod/schemas/salus/upstream/applications_salus_incremental_r_schema.json
+++ b/prod/schemas/salus/upstream/applications_salus_incremental_r_schema.json
@@ -108,7 +108,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },
@@ -125,7 +125,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8200763276510798683"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/2811384579850779811"
       ]
     }
   },
@@ -138,7 +138,7 @@
     "type": "INTEGER",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/7383053594225766630"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/181631412835176732"
       ]
     }
   },

--- a/prod/schemas/salus/upstream/bids_salus_incremental_r_schema.json
+++ b/prod/schemas/salus/upstream/bids_salus_incremental_r_schema.json
@@ -32,7 +32,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },

--- a/prod/schemas/salus/upstream/commision-rules_salus_incremental_r_schema.json
+++ b/prod/schemas/salus/upstream/commision-rules_salus_incremental_r_schema.json
@@ -52,7 +52,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/8807586895720374217"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/3220636305578737722"
       ]
     }
   },
@@ -65,7 +65,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/9049668318568313695"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/2913188619180285017"
       ]
     }
   },
@@ -74,7 +74,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/1317546347564314630"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/4790044520415782966"
       ]
     }
   },
@@ -83,7 +83,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/944449308723351742"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/46229461511594618"
       ]
     }
   },
@@ -92,7 +92,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/6318793431926689090"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/8632342627650399544"
       ]
     }
   },
@@ -101,7 +101,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/152022143728259999"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/3293766125132595059"
       ]
     }
   },
@@ -110,7 +110,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/462501529798891334/policyTags/5283687123813568820"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/8248486934170083143/policyTags/4960776295532357999"
       ]
     }
   },

--- a/prod/schemas/salus/upstream/invitations_salus_incremental_r_schema.json
+++ b/prod/schemas/salus/upstream/invitations_salus_incremental_r_schema.json
@@ -28,7 +28,7 @@
     "type": "FLOAT",
     "policyTags": {
       "names": [
-        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/1348545653474742340/policyTags/5489266776001725763"
+        "projects/sambla-data-staging-compliance/locations/europe-north1/taxonomies/655384675748637071/policyTags/5308703684021058950"
       ]
     }
   },


### PR DESCRIPTION
### What's Changed

- Schemas of **LVS**, **Raha**, **Salus**, and **Advisa History** are all updated with **Prod Taxonomy & Policy Tags**.
