### PR TITLE
encryption template is updated to inlcude is_anonymised flag

### DIFF
--- a/prod/authorized_view_service/templates/encryption_query_template.sql
+++ b/prod/authorized_view_service/templates/encryption_query_template.sql
@@ -300,13 +300,18 @@ final AS (
               ELSE NULL 
             END, ', ' 
           ),
-        ') FROM `data_with_ssn_rules` raw ',
+        '),',
+        'CASE ',
+          'WHEN (raw.', STRING_AGG(DISTINCT mlm.j_key, ', '), ' IS NOT NULL AND raw.', STRING_AGG(DISTINCT mlm.j_key, ', '), ' <> "" AND VAULT.uuid IS NOT NULL) OR LOWER(raw.', STRING_AGG(DISTINCT mlm.j_key, ', '), ') =  "anonymized" THEN TRUE ',
+          'ELSE FALSE ',
+        'END AS is_anonymised ',
+        'FROM `data_with_ssn_rules` raw ',
         'LEFT JOIN `{{compliance_project}}.compilance_database.{{gdpr_vault_table}}` VAULT ',
         'ON CAST(raw.ssn_clean AS STRING) = VAULT.ssn'
       )
 
       ELSE CONCAT(
-        'SELECT * FROM ', CASE WHEN mlm.table_schema = 'salus_group_integration' THEN '`{{ exposure_project }}.' ELSE '`{{ raw_layer_project }}.' END,
+        'SELECT *, False AS is_anonymised FROM FROM ', CASE WHEN mlm.table_schema = 'salus_group_integration' THEN '`{{ exposure_project }}.' ELSE '`{{ raw_layer_project }}.' END,
         mlm.table_schema,
         '.',
         mlm.table_name,


### PR DESCRIPTION
### PR description:

- Introduced the `is_anonymised` flag to indicate whether a certain record is encrypted or not.
- Marked national ID/SSN identifier values, that are anonymised originally by the source, as `is_anonymised = true.`

#### Important to Consider
- Currently, there are cases where we are able to encrypt the SSN identifiers and a couple of other PII fields, but not all of them due to null or empty string values.
- For use cases where we introduce join keys based on phone or email, we need to adjust the `is_anonymised` flag logic. **The anonymization status should be calculated based on the join key used with Vault.**
- For example, if the join key is ON raw.email = Vault.email, the is_anonymised flag should solely depend on whether the email values are encrypted, and vice versa for phone.